### PR TITLE
[2.13.0] Manifest Commit Lock with action UPDATE_TO_RECENT_COMMITS

### DIFF
--- a/manifests/2.13.0/opensearch-2.13.0.yml
+++ b/manifests/2.13.0/opensearch-2.13.0.yml
@@ -10,7 +10,7 @@ ci:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: '2.x'
+    ref: 2.x
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
     ref: 937bc4ecdf5ff07a1087b259c330c9b361db5c32
@@ -25,7 +25,7 @@ components:
       - windows
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: 1c839ad804fe891f9e0ead899f5405ab149e0bc2
+    ref: 8f029ebc9753888d9009547e26cada1a71a81585
     platforms:
       - linux
       - windows

--- a/manifests/2.13.0/opensearch-dashboards-2.13.0.yml
+++ b/manifests/2.13.0/opensearch-dashboards-2.13.0.yml
@@ -12,7 +12,7 @@ components:
     ref: 2a9d6dd852c2931f94d292c09ed7a7ba82a43c82
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
-    ref: '2.13'
+    ref: e3105d6a678dfe382b165263157d1226348e7734
   - name: observabilityDashboards
     repository: https://github.com/opensearch-project/dashboards-observability.git
     ref: ce4d69fc9a6973ac3232b8b58462d8b7feb1dd94


### PR DESCRIPTION
Manifest Commit Lock for Release 2.13.0 