### PR TITLE
[1.3.16] Manifest Commit Lock with action MATCH_BUILD_MANIFEST

### DIFF
--- a/manifests/1.3.16/opensearch-1.3.16.yml
+++ b/manifests/1.3.16/opensearch-1.3.16.yml
@@ -10,7 +10,7 @@ ci:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: 1.3
+    ref: 88e8e0e5e197dc8d5382e8c781bb072b67acaec2
     checks:
       - gradle:publish
       - gradle:properties:version
@@ -73,7 +73,7 @@ components:
       - common-utils
   - name: opensearch-reports
     repository: https://github.com/opensearch-project/reporting.git
-    ref: d5f8064dff99dbdb8d68caf836f7752d69985e75
+    ref: dcaba0860e363261a30e41607949e1db6a167f4e
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version


### PR DESCRIPTION
Manifest Commit Lock for Release 1.3.16 