### PR TITLE
[2.14.0] Manifest Commit Lock with action MATCH_BUILD_MANIFEST

### DIFF
--- a/manifests/2.14.0/opensearch-2.14.0.yml
+++ b/manifests/2.14.0/opensearch-2.14.0.yml
@@ -53,7 +53,7 @@ components:
       - common-utils
   - name: ml-commons
     repository: https://github.com/opensearch-project/ml-commons.git
-    ref: 5cbeaa4645d32d759cd7176a836200ba14df9318
+    ref: 679db77261d1120cda68818b0edf464ba230359b
     platforms:
       - linux
       - windows

--- a/manifests/2.14.0/opensearch-dashboards-2.14.0.yml
+++ b/manifests/2.14.0/opensearch-dashboards-2.14.0.yml
@@ -45,7 +45,7 @@ components:
     ref: 150280dd766c0f45ad3e489aecfcab295f82ad60
   - name: securityAnalyticsDashboards
     repository: https://github.com/opensearch-project/security-analytics-dashboards-plugin.git
-    ref: e7f946de234cd304d871525eb0ecb14a5513547b
+    ref: cb5ccdd0538d22f4bd81ef24432c141b090aa754
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
     ref: 5f1c9f485c2ef53e65ec0af04f217a4d4c5bce17


### PR DESCRIPTION
Manifest Commit Lock for Release 2.14.0 